### PR TITLE
Feature/delayed mock response

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,18 @@ This ensures that changing a scenario in one test, will not effect another test.
 ### Available functions
 All these functions are protractor promises, so they can be chained.
 
-#### selectScenario(json, scenarionName)
+#### selectScenario(json, scenarionName, options)
 Selects the given scenario (when calling this function without a scenario or with 'passThrough' as scenario name, the call will be passed through to the actual backend)
+
+##### Supported options
+###### hold 
+When set to true the subsequent mock-calls will not be immediately returned, but stored in a session. Use `releaseMock(mockName)` (see below) to trigger the mock call to finish.
+Very usefull for testing loading states of your UI. Use in conjunction with `browser.ignoreSynchronization = true` 
   
+#### releaseMock(mockName)
+Release a mock the was hold using the options object in `selectScenario` (see above)
+Trying to release a mock the was not hold will result in a error and failing test.
+
 #### setAllScenariosToDefault()
 Resets all mocks to the default scenarios
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Selects the given scenario (when calling this function without a scenario or wit
 ##### Supported options
 ###### hold 
 When set to true the subsequent mock-calls will not be immediately returned, but stored in a session. Use `releaseMock(mockName)` (see below) to trigger the mock call to finish.
-Very usefull for testing loading states of your UI. Use in conjunction with `browser.ignoreSynchronization = true` 
+Very usefull for testing loading states of your UI.
   
 #### releaseMock(mockName)
 Release a mock the was hold using the options object in `selectScenario` (see above)

--- a/lib/api/mocks/releaseMockHandler.js
+++ b/lib/api/mocks/releaseMockHandler.js
@@ -1,0 +1,59 @@
+(function () {
+    'use strict';
+
+    var MEDIA_TYPE_APPLICATION_JSON = 'application/json',
+        DEFAULT_HEADERS = {'Content-Type': MEDIA_TYPE_APPLICATION_JSON};
+
+    /**
+     * Handles the update mock request.
+     *
+     * #1. Find the mock matching the request information.
+     * #2. Set the selected scenario
+     * #3. Send the response back
+     *
+     * @param request The http request.
+     * @param response The http response.
+     * @param config The configuration containing all the mock information.
+     */
+    function handleRequest(request, response, config) {
+        var ngApimockId = request.headers.ngapimockid;
+        request.on('data', function (rawData) {
+            var data = JSON.parse(rawData), code, reason, chunk, oriResponse;
+
+            if(!config.sessions[ngApimockId].hold[data.identifier]) {
+                response.writeHead(404, DEFAULT_HEADERS);
+                response.end('no mock to release found');
+            } else {
+                code = config.sessions[ngApimockId].hold[data.identifier].statusCode;
+                reason = config.sessions[ngApimockId].hold[data.identifier].reasonPhrase;
+                chunk = config.sessions[ngApimockId].hold[data.identifier].chunk;
+                oriResponse = config.sessions[ngApimockId].hold[data.identifier].response;
+            }
+
+            try {
+                if(oriResponse) {
+                    oriResponse.writeHead(code, reason);
+                    oriResponse.end(chunk);
+
+                    // empty the hold session data
+                    config.sessions[ngApimockId].hold[data.identifier] = {};
+                    response.writeHead(200, DEFAULT_HEADERS);
+                    response.end();
+                } else {
+                    response.writeHead(404, DEFAULT_HEADERS);
+                    response.end('no mock to release found');
+                }
+
+            } catch (e) {
+                // #3
+                console.log(JSON.stringify(e, ["message"]));
+                response.writeHead(409, DEFAULT_HEADERS);
+                response.end(JSON.stringify(e, ["message"]));
+            }
+        });
+    }
+
+    module.exports = {
+        handleRequest: handleRequest
+    }
+})();

--- a/lib/api/mocks/updateMockHandler.js
+++ b/lib/api/mocks/updateMockHandler.js
@@ -19,7 +19,6 @@
         var ngApimockId = request.headers.ngapimockid;
         request.on('data', function (rawData) {
             var data = JSON.parse(rawData);
-
             try {
                 // #1
                 var matchingMock = config.mocks.find(function (mock) {
@@ -45,6 +44,13 @@
                             // #2
                             if (ngApimockId !== undefined) {
                                 config.sessions[ngApimockId].selections[data.identifier] = data.scenario;
+                                // in case this is a delayed call,
+                                // create empty hold object, we can store the request in
+                                if (data.hold) {
+                                    config.sessions[ngApimockId].hold = {};
+                                    config.sessions[ngApimockId].hold[data.identifier] = {};
+                                    config.sessions[ngApimockId].hold[data.identifier].hold = data.hold;
+                                }
                             } else {
                                 config.selections[data.identifier] = data.scenario;
                             }

--- a/lib/ngApimockHandler.js
+++ b/lib/ngApimockHandler.js
@@ -85,14 +85,15 @@
 
         if (matchingMock) {
             var ngApimockId = request.headers.ngapimockid,
-                selection, variables, payload;
+                selection, variables, payload, hold;
 
             request.on('data', function (rawData) {
                 payload = rawData.toString();
             });
 
             if (ngApimockId !== undefined) {
-                if (config.sessions[ngApimockId] === undefined) { // if there is no session selections present, add the defaults
+                if (config.sessions[ngApimockId] === undefined) {
+                    // if there is no session selections present, add the defaults
                     config.sessions[ngApimockId] = {
                         selections: JSON.parse(JSON.stringify(config.defaults)),
                         variables: {}
@@ -100,6 +101,11 @@
                 }
                 selection = config.sessions[ngApimockId].selections[matchingMock.identifier];
                 variables = config.sessions[ngApimockId].variables;
+
+                // determine if we need to hold the response
+                if(config.sessions[ngApimockId].hold && config.sessions[ngApimockId].hold[matchingMock.identifier]) {
+                    hold = config.sessions[ngApimockId].hold[matchingMock.identifier].hold;
+                }
             } else {
                 selection = config.selections[matchingMock.identifier];
                 variables = config.variables;
@@ -123,8 +129,17 @@
                     chunk = JSON.stringify(mockResponse.data ? updateData(mockResponse.data, variables) : (matchingMock.isArray ? [] : {}));
                 }
 
-                response.writeHead(statusCode, reasonPhrase);
-                response.end(chunk);
+                if (hold) {
+                    // store the response object and all needed values in the session, do not finish the call here
+                    config.sessions[ngApimockId].hold[matchingMock.identifier].statusCode = statusCode;
+                    config.sessions[ngApimockId].hold[matchingMock.identifier].reasonPhrase = reasonPhrase;
+                    config.sessions[ngApimockId].hold[matchingMock.identifier].chunk = chunk;
+                    config.sessions[ngApimockId].hold[matchingMock.identifier].response = response;
+
+                } else {
+                    response.writeHead(statusCode, reasonPhrase);
+                    response.end(chunk);
+                }
 
                 if (config.record) {
                     storeRecording(payload, chunk, request, statusCode, matchingMock);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,13 +4,11 @@
         updateMockHandler = require('./api/mocks/updateMockHandler.js'),
         defaultMockHandler = require('./api/mocks/defaultMockHandler.js'),
         passThroughMockHandler = require('./api/mocks/passThroughMockHandler.js'),
-
+        releaseMockHandler = require('./api/mocks/releaseMockHandler.js'),
         recordHandler = require('./api/mocks/recordHandler.js'),
-
         getVariablesHandler = require('./api/variables/getVariablesHandler.js'),
         addOrUpdateVariableHandler = require('./api/variables/addOrUpdateVariableHandler.js'),
         deleteVariableHandler = require('./api/variables/deleteVariableHandler.js'),
-
         ngApimockHandler = require('./ngApimockHandler.js'),
 
         config = {
@@ -71,6 +69,8 @@
             getMocksHandler.handleRequest(request, response, config);
         } else if (request.url === '/ngapimock/mocks' && request.method === 'PUT') {
             updateMockHandler.handleRequest(request, response, config);
+        } else if (request.url === '/ngapimock/mocks/release' && request.method === 'POST') {
+            releaseMockHandler.handleRequest(request, response, config);
         } else if (request.url === '/ngapimock/mocks/defaults' && request.method === 'PUT') {
             defaultMockHandler.handleRequest(request, response, config);
         } else if (request.url === '/ngapimock/mocks/passthroughs' && request.method === 'PUT') {

--- a/templates/protractor.mock.js
+++ b/templates/protractor.mock.js
@@ -34,6 +34,7 @@
         var deferred = protractor.promise.defer(), hold;
 
         if (options && options.hold) {
+            browser.ignoreSynchronization = true;
             hold = options.hold;
         }
         // #1
@@ -73,6 +74,7 @@
      * @param {String} name The name of the mock
      */
     function releaseMock(name) {
+        browser.ignoreSynchronization = false;
         var deferred = protractor.promise.defer();
         var response = request('POST', baseUrl + '/mocks/release', {
             headers: {

--- a/templates/protractor.mock.js
+++ b/templates/protractor.mock.js
@@ -28,10 +28,14 @@
      *
      * @param {Object | String} data The data object containing all the information for an expression or the name of the mock.
      * @param scenario The scenario that is selected to be returned when the api is called.
+     * @param {Object} options Currently only supports 'hold' property to delay response of a mock call
      */
-    function selectScenario(data, scenario) {
-        var deferred = protractor.promise.defer();
-        
+    function selectScenario(data, scenario, options) {
+        var deferred = protractor.promise.defer(), hold;
+
+        if (options && options.hold) {
+            hold = options.hold;
+        }
         // #1
         var identifier;
         if (typeof data === 'string') { // name of the mock
@@ -49,12 +53,38 @@
             },
             json: {
                 identifier: identifier,
-                scenario: scenario || null
+                scenario: scenario || null,
+                hold: hold
             }
         });
 
         if (response.statusCode !== 200) {
             deferred.reject('Could not select scenario [' + scenario + ']');
+        } else {
+            deferred.fulfill();
+        }
+        return deferred.promise;
+    }
+
+    /**
+     * release a mock that was hold in the selectScenario function
+     * This feature only works when using named mocks (i.e. it does not work by expression
+     * Also releasing is independent of the selected scenario
+     * @param {String} name The name of the mock
+     */
+    function releaseMock(name) {
+        var deferred = protractor.promise.defer();
+        var response = request('POST', baseUrl + '/mocks/release', {
+            headers: {
+                'Content-Type': 'application/json',
+                'ngapimockid': ngapimockid
+            },
+            json: {
+                identifier: name
+            }
+        });
+        if (response.statusCode !== 200) {
+            deferred.reject('Could not release mock with name [' + name + ']');
         } else {
             deferred.fulfill();
         }
@@ -172,6 +202,7 @@
     /** This Protractor mock allows you to specify which scenario from your json api files you would like to use for your tests. */
     module.exports = {
         selectScenario: selectScenario,
+        releaseMock: releaseMock,
         addMockModule: addMockModule,
         removeMockModule: removeMockModule,
         setAllScenariosToDefault: setAllScenariosToDefault,

--- a/test/example/js/some.controller.js
+++ b/test/example/js/some.controller.js
@@ -5,8 +5,12 @@
         var vm = this;
 
         var fetch = function () {
+            vm.loading = true;
+            vm.success = false;
             api.fetch({x: 'x', y: 'y'}, function (data) {
                 vm.data = data;
+                vm.loading = false;
+                vm.success = true;
             }, function (response) {
                 vm.error = response.status;
             });
@@ -34,11 +38,11 @@
 
         vm.refresh = function () {
             fetch();
-        }
+        };
 
         vm.download = function() {
             api.download({});
-        }
+        };
     }
 
     SomeController.$inject = ['api', 'shadowLogger'];

--- a/test/example/partials/example.partial.html
+++ b/test/example/partials/example.partial.html
@@ -14,4 +14,9 @@
     </p>
 
     <h1>Get binary data with service</h1><button ng-click="ctrl.download()">download</button>
+
+    <h1>Get data with delay using the hold function</h1>
+    <button ng-click="ctrl.refresh()" id="delayed-button">get data</button>
+    <div ng-if="ctrl.loading" id="loading-message">Getting your data, not yet ready</div>
+    <div ng-if="ctrl.success" id="loading-success">Loading done</div>
 </div>

--- a/test/protractor/protractor.feature
+++ b/test/protractor/protractor.feature
@@ -73,3 +73,11 @@ Feature: ngApimock - protractor usage (protractor.mock.js)
   Scenario: When I select a scenario that returns a file the api call should return the selected scenario response
     When I click download
     Then a file should be downloaded
+
+  Scenario: use the hold option to delay the response
+    Given the used mock is delayed
+    When I click the button to get the data
+    Then I see a loading warning
+    When the mock is released
+    Then I don't see the loading warning
+    And I see a success message

--- a/test/protractor/step_definitions/protractor.steps.js
+++ b/test/protractor/step_definitions/protractor.steps.js
@@ -82,7 +82,6 @@
 
         this.Given(/^the used mock is delayed$/, function (callback) {
             ngApimock.selectScenario('getAllTodos', 'some-meaningful-scenario-name', { hold: true }).then(callback);
-            browser.ignoreSynchronization = true;
         });
 
         this.When(/^I click the button to get the data$/, function (callback) {
@@ -94,7 +93,6 @@
         });
 
         this.When(/^the mock is released$/, function (callback) {
-            browser.ignoreSynchronization = false;
             ngApimock.releaseMock('getAllTodos').then(callback);
         });
 

--- a/test/protractor/step_definitions/protractor.steps.js
+++ b/test/protractor/step_definitions/protractor.steps.js
@@ -79,5 +79,31 @@
                 callback();
             });
         });
+
+        this.Given(/^the used mock is delayed$/, function (callback) {
+            ngApimock.selectScenario('getAllTodos', 'some-meaningful-scenario-name', { hold: true }).then(callback);
+            browser.ignoreSynchronization = true;
+        });
+
+        this.When(/^I click the button to get the data$/, function (callback) {
+            element(by.id('delayed-button')).click().then(callback);
+        });
+
+        this.Then(/^I see a loading warning$/, function (callback) {
+            expect(element(by.id('loading-message')).isPresent()).to.eventually.be.true.and.notify(callback);
+        });
+
+        this.When(/^the mock is released$/, function (callback) {
+            browser.ignoreSynchronization = false;
+            ngApimock.releaseMock('getAllTodos').then(callback);
+        });
+
+        this.Then(/^I don't see the loading warning$/, function (callback) {
+            expect(element(by.id('loading-message')).isPresent()).to.eventually.be.false.and.notify(callback);
+        });
+
+        this.Then(/^I see a success message$/, function (callback) {
+            expect(element(by.id('loading-success')).isPresent()).to.eventually.be.true.and.notify(callback);
+        });
     };
 })();


### PR DESCRIPTION
Added option to hold back the response of a mock-call. This can be used in conjunction with browser.ignoreSynchronisation to test UI behaviour when API calls are pending.

see protractor tests for implementation