### PR TITLE
Fix recording bug

### DIFF
--- a/lib/ngApimockHandler.js
+++ b/lib/ngApimockHandler.js
@@ -50,7 +50,7 @@
      */
     function storeRecording(payload, chunk, request, statusCode, mock) {
         var result = {
-            data: chunk,
+            data: chunk.toString('utf8'),
             payload: payload,
             datetime: new Date().getTime(),
             method: request.method,


### PR DESCRIPTION
If serving a file through a mock, chunk will be a buffer instead of a string. So add decoding to utf8 for the recording functionality.

Before: If recording a mock which response contains an other json file, the GUI will show the response as [object object].
After: After decoding the buffer to a utf8 string the GUI shows the response correctly.