### PR TITLE
feat: add Protractor 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,24 @@ another scenario response to be returned.
 NgApimock also works when running multiple tests concurrent, by using the protract session id of the test. 
 This ensures that changing a scenario in one test, will not effect another test. 
 
+### Using Angular 2 or higher with Protractor?
+If you are using Angular 2 or higher in combination with Protractor you will need to add the following to you configuration.
+
+**Protractor 4**
+```js
+exports.config = {
+    useAllAngular2AppRoots: true
+};
+```
+**Protractor 5 or higher**
+```js
+exports.config = {
+    ngApimockOpts: {
+        angularVersion: 2  // {number} provide major version of Angular
+    }
+};
+```
+
 ### Available functions
 All these functions are protractor promises, so they can be chained.
 

--- a/templates/protractor.mock.js
+++ b/templates/protractor.mock.js
@@ -19,7 +19,10 @@
 
     /** Make sure that angular uses the ngapimock identifier for the requests. */
     browser.getProcessedConfig().then(function (config) {
-        if (config.useAllAngular2AppRoots) {
+        // As of protractor 5.0.0 the flag config.useAllAngular2AppRoots has been deprecated, to let protractor tell
+        // ngApimock that Angular 2 is used a custom object needs to be provided with the angular version in it
+        // See: https://github.com/angular/protractor/blob/master/CHANGELOG.md#features-2
+        if (config.useAllAngular2AppRoots || ('ngApimockOpts' in config && config.ngApimockOpts.angularVersion > 1)) {
             // angular 2 does not have addMockModule support @see https://github.com/angular/protractor/issues/3092
             // fallback to cookie
             require('hooker').hook(browser, 'get', {


### PR DESCRIPTION
As of protractor 5.0.0 the flag `config.useAllAngular2AppRoots` has been deprecated, to let protractor tell ngApimock that Angular 2 is used a custom object needs to be provided with the angular version in it, [see](https://github.com/angular/protractor/blob/master/CHANGELOG.md#features-2).

This object can be used in the feature to add more options.