### PR TITLE
Bugfix: handle a request after it is ended.

### DIFF
--- a/lib/ngApimockHandler.ts
+++ b/lib/ngApimockHandler.ts
@@ -13,6 +13,7 @@ abstract class NgApimockHandler implements Handler {
     /**
      * Gets the selection.
      * @param registry The registry.
+     * @param identifier The mock identifier.
      * @param ngApimockId The ngApimock id.
      * @return selection The selection.
      */
@@ -62,78 +63,79 @@ abstract class NgApimockHandler implements Handler {
         if (match) {
             const selection = this.getSelection(registry, match.identifier, ngApimockId),
                 variables = this.getVariables(registry, ngApimockId),
-                mockResponse = match.responses[selection];
+                mockResponse = match.responses[selection],
+                requestDataChunks: Array<Buffer> = [];
 
-            request.on('data', (rawData: string) => {
-                payload = rawData.toString();
+            request.on('data', (rawData: Buffer) => {
+                requestDataChunks.push(rawData);
+            });
 
+            request.on('end', () => {
+                payload = Buffer.concat(requestDataChunks).toString();
                 if (mockResponse !== undefined) {
-                    if (!!this.getEcho(registry, match.identifier, ngApimockId)) {
-                        console.log(match.method + ' request made on \'' + match.expression + '\' with payload: ',
-                            payload);
+                    if (this.getEcho(registry, match.identifier, ngApimockId)) {
+                        console.log(match.method + ' request made on \'' + match.expression + '\' with payload: ', payload);
+                    }
+
+                    const statusCode = mockResponse.status || 200;
+                    const jsonCallbackName = this.getJsonCallbackName(request.url);
+                    let headers, chunk;
+
+                    if (this.isBinaryResponse(mockResponse)) {
+                        headers = mockResponse.headers || httpHeaders.CONTENT_TYPE_BINARY;
+                        chunk = fs.readFileSync(mockResponse.file);
+                    } else {
+                        headers = mockResponse.headers || httpHeaders.CONTENT_TYPE_APPLICATION_JSON;
+                        chunk = this.updateData(mockResponse.data, variables, (match.isArray ? [] : {}));
+                    }
+
+                    if (jsonCallbackName !== false) {
+                        chunk = jsonCallbackName + '(' + chunk + ')';
+                    }
+
+                    const mockDelay = this.getDelay(registry, match.identifier, ngApimockId);
+                    const _delay = mockDelay === null || mockDelay === undefined ? mockResponse.delay : mockDelay;
+
+                    this.delay(_delay);
+                    response.writeHead(statusCode, headers);
+                    response.end(chunk);
+
+                    if (registry.record) {
+                        this.storeRecording(payload, chunk, request, statusCode, registry, match.identifier);
+                    }
+                } else {
+                    // remove the recording header to stop recording after this call succeeds
+                    if (registry.record && !request.headers.record) {
+                        const headers = request.headers;
+                        const host = <string>headers.host;
+                        const options = {
+                            host: host.split(':')[0],
+                            port: Number(host.split(':')[1]),
+                            path: request.url,
+                            method: request.method,
+                            headers: headers
+                        };
+
+                        headers.record = 'off';
+
+                        const req = http.request(options, (res: http.IncomingMessage) => {
+                            res.setEncoding('utf8');
+                            res.on('data', (chunk: Buffer) => {
+                                this.storeRecording(payload, chunk.toString('utf8'), request, res.statusCode, registry,
+                                    match.identifier);
+                                response.end(chunk);
+                            });
+                        });
+
+                        req.on('error', function (e) {
+                            response.end(e);
+                        });
+                        req.end();
+                    } else {
+                        next();
                     }
                 }
             });
-
-            if (mockResponse !== undefined) {
-                const statusCode = mockResponse.status || 200;
-                const jsonCallbackName = this.getJsonCallbackName(request.url);
-                let headers, chunk;
-
-                if (this.isBinaryResponse(mockResponse)) {
-                    headers = mockResponse.headers || httpHeaders.CONTENT_TYPE_BINARY;
-                    chunk = fs.readFileSync(mockResponse.file);
-                } else {
-                    headers = mockResponse.headers || httpHeaders.CONTENT_TYPE_APPLICATION_JSON;
-                    chunk = this.updateData(mockResponse.data, variables, (match.isArray ? [] : {}));
-                }
-
-                if (jsonCallbackName !== false) {
-                    chunk = jsonCallbackName + '(' + chunk + ')';
-                }
-
-                const mockDelay = this.getDelay(registry, match.identifier, ngApimockId);
-                const _delay = mockDelay === null || mockDelay === undefined ? mockResponse.delay : mockDelay;
-
-                this.delay(_delay);
-                response.writeHead(statusCode, headers);
-                response.end(chunk);
-
-                if (registry.record) {
-                    this.storeRecording(payload, chunk, request, statusCode, registry, match.identifier);
-                }
-            } else {
-                // remove the recording header to stop recording after this call succeeds
-                if (registry.record && !request.headers.record) {
-                    const headers = request.headers;
-                    const host = <string>headers.host;
-                    const options = {
-                        host: host.split(':')[0],
-                        port: Number(host.split(':')[1]),
-                        path: request.url,
-                        method: request.method,
-                        headers: headers
-                    };
-
-                    headers.record = 'off';
-
-                    const req = http.request(options, (res: http.IncomingMessage) => {
-                        res.setEncoding('utf8');
-                        res.on('data', (chunk: Buffer) => {
-                            this.storeRecording(payload, chunk.toString('utf8'), request, res.statusCode, registry,
-                                match.identifier);
-                            response.end(chunk);
-                        });
-                    });
-
-                    req.on('error', function (e) {
-                        response.end(e);
-                    });
-                    req.end();
-                } else {
-                    next();
-                }
-            }
         } else {
             next();
         }


### PR DESCRIPTION
I noticed an issue when trying ng-apimock with angular-cli (as described in ANGULAR_CLI.md):
When a POST request with a body is done then the mocked response is returned before the request has been ended.
This often causes issues in the Angular proxy, either by throwing an error "[HPM] Error occurred while trying to proxy request" or by responding with half of the mocked JSON response.

Waiting on the 'end' event of the HTTP-request fixed this issue.