### PR TITLE
fix(ngApimockHandler): match expression on decoded url (#33)

### DIFF
--- a/lib/ngApimockHandler.ts
+++ b/lib/ngApimockHandler.ts
@@ -209,7 +209,7 @@ abstract class NgApimockHandler implements Handler {
      * @returns {string|boolean} callbackName Either the name or false.
      */
     private getJsonCallbackName(requestUrl: string): string | boolean {
-        const url_parts = url.parse(requestUrl, true);
+        const url_parts: any = url.parse(requestUrl, true);
         if (!url_parts.query || !url_parts.query.callback) {
             return false;
         }

--- a/lib/ngApimockHandler.ts
+++ b/lib/ngApimockHandler.ts
@@ -164,7 +164,7 @@ abstract class NgApimockHandler implements Handler {
      */
     getMatchingMock(mocks: Mock[], requestUrl: string, method: string): Mock {
         return mocks.filter(_mock => {
-            const expressionMatches = new RegExp(_mock.expression).exec(requestUrl) !== null,
+            const expressionMatches = new RegExp(_mock.expression).exec(decodeURI(requestUrl)) !== null,
                 methodMatches = _mock.method === method;
 
             return expressionMatches && methodMatches;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "build": "node node_modules/typescript/bin/tsc",
     "verify": "node node_modules/tslint/bin/tslint -p tsconfig.json",
+    "verify-type-check": "node node_modules/tslint/bin/tslint -p tsconfig.json --type-check",
     "local": "node node_modules/jasmine-node/bin/jasmine-node test/unit/*.spec.js && node node_modules/protractor/bin/protractor test/protractor/config/protractor-local-interface.conf.js && node node_modules/protractor/bin/protractor test/protractor/config/protractor-local-protractor.conf.js",
     "travis-interface": "node node_modules/protractor/bin/protractor test/protractor/config/protractor-travis-interface.conf.js",
     "travis-protractor": "node node_modules/protractor/bin/protractor test/protractor/config/protractor-travis-protractor.conf.js",


### PR DESCRIPTION
By decoding the requestUrl before matching it against the configured expression, it will be matched consistently across different platforms/browsers. (also see #33)