### PR TITLE
Added standalone posibility with express server. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "tslint": "5.6.0",
     "tslint-eslint-rules": "4.1.1",
     "typescript": "2.4.2",
-    "vrsource-tslint-rules": "5.1.1"
+    "vrsource-tslint-rules": "5.1.1",
+    "express": "4.16.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,19 @@
+const ngApimock = require('./tasks/index')();
+const express = require('express');
+const app = express();
+ngApimock.run({
+    "src": "test/mocks",
+    "outputDir": ".tmp/ngApimock",
+    "done": function () {
+    }
+});
+app.set('port', 3000);
+
+// process the api calls through ng-apimock
+app.use(require('./lib/utils').ngApimockRequest);
+// serve the mocking interface for local development
+app.use('/mocking', express.static('.tmp/ngApimock'));
+
+app.listen(app.get('port'), function () {
+    console.info('ngapimock running on port', app.get('port'));
+});


### PR DESCRIPTION
Also usefull for implementation example. Use npm start to start ng-apimock standalone