### PR TITLE
[WIP]Feature: Re-usability of mocks via JS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-apimock",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tasks/processor.ts
+++ b/tasks/processor.ts
@@ -26,6 +26,19 @@ class Processor {
             root: '/'
         }).forEach((file) =>
             mocks.push(fs.readJsonSync(path.join(directory, file))));
+
+        const dynamicMocks = glob.sync('**/*.builder.js', {
+            cwd: directory,
+            root: '/'
+        }).map(file => {
+            return require(path.relative(path.resolve(__dirname), path.resolve(path.join(directory, file))));
+        });
+
+        dynamicMocks.forEach(mock => {
+            if(mock.default) 
+                mocks.push(mock.default);
+        })
+
         return mocks;
     }
 

--- a/tasks/processor.ts
+++ b/tasks/processor.ts
@@ -35,7 +35,7 @@ class Processor {
         });
 
         dynamicMocks.forEach(mock => {
-            if(mock.default) {
+            if (mock.default) {
                 mocks.push(mock.default);
             }
         })

--- a/tasks/processor.ts
+++ b/tasks/processor.ts
@@ -35,8 +35,9 @@ class Processor {
         });
 
         dynamicMocks.forEach(mock => {
-            if(mock.default) 
+            if(mock.default) {
                 mocks.push(mock.default);
+            }
         })
 
         return mocks;

--- a/test/mocks/api/objects/groceries.js
+++ b/test/mocks/api/objects/groceries.js
@@ -1,0 +1,3 @@
+module.exports = { 
+    groceries: [{"title":"buy 12 apples from Mike"}, {"title": "buy"}]
+}

--- a/test/mocks/api/some-api-using-objects.builder.js
+++ b/test/mocks/api/some-api-using-objects.builder.js
@@ -1,0 +1,26 @@
+const groceries = require('./objects/groceries');
+
+module.exports.default = { 
+    "expression": "online\/rest\/some\/api\/.*\/and\/.*",
+    "method": "GET",
+    "name": "list",
+    "isArray": true,
+    "responses": {
+        "groceries": {
+            "status": 200,
+            "data": groceries,
+            "headers": {"Content-type":"application/json"},
+            "statusText": "text"
+        },
+        "wishes": {
+            "data": [{"title":"Ferrari f40"}, {"title": "Koenigsegg One:1"}]
+        },
+        "other": {
+            "data": [{"title":"Red-bull RB13"}],
+            "delay": 4000
+        },
+        "internal-server-error": {
+            "status":500
+        }
+    }
+};


### PR DESCRIPTION
_Note: Not done implementing but before I go further with this I wanted to see what people's thoughts on this pattern was._ 

**Problem Statement:** So while using this framework for mocks I came across the problem that I have many data-sets with minimal change between scenarios maybe only testing a new field or flag for example. This caused a lot of copy pasting, or redundant code to be necessary while creating new scenarios.

**Potential Solution:** Provide users the ability to utilize exports / imports to reuse parts of their scenarios that may be shared by allowing for the creation of mocks in Javascript as well as JSON. 

The idea behind this is simple in that a user would be able to create some part of their response and then just import that section (such as an array of groceries) into their other scenarios, while only changing the single things they wanted. This is extremely expandable if people were to use the spread operator `...` and then just override specific values they were interested in changing.

This PR was me spending all of 10 minutes just hacking something together to see the feasibility of it. I was able to get it to successfully read the JS files and include them as mocks. I need to clean this up entirely so I do not intend for this PR to be improved but I wanted feedback as to the idea or feature before I spend more time on it (as they say time is money). 

Also should this be something in `@ng-apimock/core`?